### PR TITLE
Upgraded FLTK so it compiles on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 .SUFFIXES:
 UNAME := $(shell uname)
 FLTK_CONFIG = local/bin/fltk-config
-FLTK_TAR = fltk-1.3.2-source.tar.gz
-FLTK_URL = http://fltk.org/pub/fltk/1.3.2/$(FLTK_TAR)
-FLTK_DIR = build/fltk-1.3.2
+FLTK_TAR = fltk-1.3.3-source.tar.gz
+FLTK_URL = http://fltk.org/pub/fltk/1.3.3/$(FLTK_TAR)
+FLTK_DIR = build/fltk-1.3.3
 
 CXX = g++
 FLAGS = -g $(shell $(FLTK_CONFIG) --use-gl --cxxflags)


### PR DESCRIPTION
FLTK 1.3.2 had compiler errors on the version of clang shipped with OS X.
